### PR TITLE
[SRE-469] Reverted back to babel 6 as it broke the plugin after updating it

### DIFF
--- a/dist/datasource.js
+++ b/dist/datasource.js
@@ -256,7 +256,7 @@ System.register(['lodash', './showdown.min.js', './query_builder'], function (_e
               var dataResponse = _.map(result.series, function (series, i) {
                 var target = targets[i];
                 return {
-                  'target': target.alias || series.expression,
+                  'target': series.expression,
                   'datapoints': _.map(series.pointlist, function (point) {
                     return [point[1], point[0]];
                   })

--- a/dist/partials/query.editor.html
+++ b/dist/partials/query.editor.html
@@ -1,7 +1,7 @@
 <query-editor-row query-ctrl="ctrl" has-text-edit-mode="true" can-collapse="true">
 
   <div class="gf-form" ng-if="ctrl.target.rawQuery">
-    <input type="text" class="gf-form-input" ng-model="ctrl.target.query" spellcheck="false" ng-blur="ctrl.refresh()"></input>
+    <input type="text" class="gf-form-input" ng-model="ctrl.target.query" spellcheck="false" ng-blur="ctrl.checkQuery()"></input>
   </div>
 
   <div ng-if="!ctrl.target.rawQuery">
@@ -21,7 +21,7 @@
       </div>
 
       <div class="gf-form gf-form--grow">
-        <div class="gf-form-label gf-form-label--grow"></div>
+        <div class="gf-form-label gf-form-label--grow"></div> 
       </div>
     </div>
 
@@ -54,6 +54,17 @@
         <div class="gf-form-label gf-form-label--grow"></div>
       </div>
 
+    </div>
+
+    <div class="gf-form-inline">
+      <div class="gf-form max-width-30">
+        <label class="gf-form-label query-keyword width-7">GROUP BY</label>
+        <input type="text" class="gf-form-input" ng-model="ctrl.target.groups" spellcheck='false' placeholder="Tags (separate by comma)" ng-blur="ctrl.refresh()">
+      </div>
+
+      <div class="gf-form gf-form--grow">
+        <div class="gf-form-label gf-form-label--grow"></div>
+      </div>
     </div>
 
     <div class="gf-form-inline">

--- a/dist/query_builder.js
+++ b/dist/query_builder.js
@@ -35,6 +35,18 @@ System.register(['lodash', './dfunc'], function (_export, _context) {
       query += '{*}';
     }
 
+    if (target.groups) {
+      var groups = target.groups.split(",");
+      query += ' by {';
+      for (var i = 0; i < groups.length; ++i) {
+        query += groups[i];
+        if (i !== groups.length - 1) {
+          query += ',';
+        }
+      }
+      query += '}';
+    }
+
     if (target.as) {
       query += '.' + target.as + '()';
     }
@@ -54,7 +66,7 @@ System.register(['lodash', './dfunc'], function (_export, _context) {
     _.each(groupedFuncs.wraps, function (func) {
       query = func.render(query);
     });
-
+  
     return query;
   }
 

--- a/dist/query_ctrl.js
+++ b/dist/query_ctrl.js
@@ -125,6 +125,25 @@ System.register(['lodash', './dfunc', 'app/plugins/sdk', './func_editor', './add
           key: 'toggleEditorMode',
           value: function toggleEditorMode() {
             this.target.rawQuery = !this.target.rawQuery;
+            if (this.target.rawQuery)
+              this.target.query = queryBuilder.buildQuery(this.target);
+          }
+        }, {
+          key: 'getCollapsedText',
+          value: function getCollapsedText() {
+            if (this.target.rawQuery) {
+              return this.target.query;
+            } else {
+              return queryBuilder.buildQuery(this.target);
+            }
+          }
+        }, {
+          key: 'checkQuery',
+          value: function checkQuery() {
+            if (!(this.target.query || this.target.query.length != 0)) 
+            // to avoid 400 Bad Request, this is the default query
+              this.target.query = 'undefined:undefined{*}';
+            this.panelCtrl.refresh();
           }
         }, {
           key: 'getMetrics',
@@ -170,11 +189,7 @@ System.register(['lodash', './dfunc', 'app/plugins/sdk', './func_editor', './add
         }, {
           key: 'asChanged',
           value: function asChanged() {
-            if (this.asSegment.value === 'None') {
-              this.target.as = null;
-            } else {
-              this.target.as = this.asSegment.value;
-            }
+            this.target.as = this.asSegment.value;
             this.panelCtrl.refresh();
           }
         }, {
@@ -240,15 +255,6 @@ System.register(['lodash', './dfunc', 'app/plugins/sdk', './func_editor', './add
             this.fixTagSegments();
 
             this.panelCtrl.refresh();
-          }
-        }, {
-          key: 'getCollapsedText',
-          value: function getCollapsedText() {
-            if (this.target.rawQuery) {
-              return this.target.query;
-            } else {
-              return queryBuilder.buildQuery(this.target);
-            }
           }
         }]);
 

--- a/src/datasource.js
+++ b/src/datasource.js
@@ -1,374 +1,433 @@
-import _ from 'lodash';
-import showdown from './showdown.min.js';
-import * as queryBuilder from './query_builder';
+'use strict';
 
-export class DataDogDatasource {
+System.register(['lodash', './showdown.min.js', './query_builder'], function (_export, _context) {
+  "use strict";
 
-  constructor (instanceSettings, backendSrv, templateSrv) {
-    this.type = instanceSettings.type;
-    this.url = instanceSettings.url;
-    this.name = instanceSettings.name;
-    this.api_key = instanceSettings.jsonData.api_key;
-    this.application_key = instanceSettings.jsonData.app_key;
-    this.supportMetrics = true;
-    this.backendSrv = backendSrv;
-    this.templateSrv = templateSrv;
-    this._cached_metrics = false;
-  }
+  var _, showdown, queryBuilder, _createClass, DataDogDatasource;
 
-  // Function to check Datasource health
-  testDatasource() {
-    return this.invokeDataDogApiRequest('/downtime')
-    .then(() => {
-      return {
-        status: "success",
-        title: "Success",
-        message: "Data source is working"
-      };
-    })
-    .catch(error => {
-      var message = "Connection error";
-      if (error && error.message) {
-        message = error.message;
-      }
-
-      return {
-        status: "error",
-        title: "Error",
-        message: message
-      };
-    });
-  }
-
-  tagFindQuery() {
-    return this.getTagsFromCache()
-    .then(tags => {
-      return _.map(tags, (hosts, tag) => {
-        return {
-          text: tag,
-          value: tag,
-        };
-      });
-    });
-  }
-
-  metricFindQuery(query) {
-    if (query === 'tag') {
-      return this.tagFindQuery();
+  function _classCallCheck(instance, Constructor) {
+    if (!(instance instanceof Constructor)) {
+      throw new TypeError("Cannot call a class as a function");
     }
-
-    if (this._cached_metrics) {
-      return Promise.resolve(this._cached_metrics);
-    }
-
-    if (this.fetching) {
-      return this.fetching;
-    }
-
-    var d = new Date();
-    d.setDate(d.getDate() - 1);
-    var from = Math.floor(d.getTime() / 1000);
-
-    this.fetching = this.getMetrics(from).then(metrics => {
-      this._cached_metrics = _.map(metrics, metric => {
-        return {
-          text: metric,
-          value: metric,
-        };
-      });
-
-      return this._cached_metrics;
-    });
-
-    return this.fetching;
   }
 
-  getTagKeys() {
-    return this.getTagsFromCache()
-    .then(tagsHosts => {
-      let tags = Object.keys(tagsHosts);
-      let kv = mapTagsToKVPairs(tags);
-      let grafanaTags = Object.keys(kv);
-
-      return grafanaTags.map(tag => {
-        return {
-          text: tag,
-          value: tag,
-        };
-      });
+  /*
+   * Convert tags to key-value pairs
+   * [region:east, region:nw] => {region: [east, nw]}
+   */
+  function mapTagsToKVPairs(tags) {
+    var kv_tags = _.filter(tags, function (tag) {
+      return tag.indexOf(':') !== -1;
     });
-  }
 
-  getTagValues(options) {
-    return this.getTagsFromCache()
-    .then(tagsHosts => {
-      let tags = Object.keys(tagsHosts);
-      let kv = mapTagsToKVPairs(tags);
-      let grafanaValues = kv[options.key];
-      return grafanaValues.map(val => {
-        return {
-          text: val,
-          value: val,
-        };
-      });
+    var kv_pairs = kv_tags.map(function (tag) {
+      return tag.split(':', 2); // Limit to 2
     });
-  }
 
-  query(options) {
-    var from = Math.floor(options.range.from.valueOf() / 1000);
-    var to = Math.floor(options.range.to.valueOf() / 1000);
+    var kv_object = {};
+    kv_pairs.forEach(function (pair) {
+      var key = pair[0];
+      var val = pair[1];
 
-    var targets = options.targets.filter(function (t) { return !t.hide; });
-
-    if (targets.length <= 0) {
-      return Promise.resolve({data: []});
-    }
-
-    // add global adhoc filters
-    let adhocFilters = this.templateSrv.getAdhocFilters(this.name);
-
-    var queries = _.map(targets, target => {
-      let query;
-      if (target.rawQuery) {
-        query = target.query;
+      if (kv_object[key]) {
+        kv_object[key].push(val);
       } else {
-        query = queryBuilder.buildQuery(target, adhocFilters);
+        kv_object[key] = [val];
       }
-      return query;
     });
 
-    var queryString = queries.join(',');
-    queryString = this.templateSrv.replace(queryString, options.scopedVars, dataDogTagFormat);
-
-    var params = {
-      from: from,
-      to: to,
-      query: queryString,
-    };
-
-    return this.invokeDataDogApiRequest('/query', params)
-    .then(result => {
-      var dataResponse = _.map(result.series, (series, i) => {
-        var target = targets[i];
-        return {
-          'target': target.alias || series.expression,
-          'datapoints': _.map(series.pointlist, point => {
-            return [point[1], point[0]];
-          })
-        };
-      });
-
-      return {data: dataResponse};
-    });
+    return kv_object;
   }
 
-  annotationQuery(options) {
-    let timeFrom = Math.floor(options.range.from.valueOf() / 1000);
-    let timeTo = Math.floor(options.range.to.valueOf() / 1000);
-    let {priority, sources, tags} = options.annotation;
+  /*
+   * Convert DataDog event text from markdown to pure HTML
+   * http://docs.datadoghq.com/guides/markdown/
+   */
+  function convertDataDogMdToHtml(str) {
+    var MD_START = '%%%\n';
+    var MD_END = '\n%%%';
 
-    return this.getEventStream(timeFrom, timeTo, priority, sources, tags)
-    .then(eventStreams => {
-      let eventAnnotations = eventStreams.map(eventStream => {
-        let allEvents = eventStream.children;
-        let filteredEvents = _.filter(allEvents, event => {
-          return event.alert_type !== 'success';
-        });
+    var md_start_index = str.indexOf(MD_START) + MD_START.length;
+    var md_end_index = str.indexOf(MD_END);
+    var md = str.substring(md_start_index, md_end_index);
+    md = removeImagesFromDataDogMarkdown(md);
 
-        return _.map(filteredEvents, event => {
-          let renderedText = eventStream.text;
-          if (isDataDogMarkdown(eventStream.text)) {
-            renderedText = convertDataDogMdToHtml(eventStream.text);
+    var converter = new showdown.Converter();
+    return converter.makeHtml(md);
+  }
+
+  function isDataDogMarkdown(str) {
+    var MD_START = '%%%\n';
+    return str.indexOf(MD_START) >= 0;
+  }
+
+  function removeImagesFromDataDogMarkdown(str) {
+    var dataDogImagePattern = /\[{0,1}\!\[.*\]\(https{0,1}\:\/\/p\.datadoghq\.com\/snapshot.+\)/g;
+    return str.replace(dataDogImagePattern, '');
+  }
+
+  function dataDogTagFormat(value) {
+    if (_.isArray(value)) {
+      return value.join(',');
+    }
+    return value;
+  }
+  return {
+    setters: [function (_lodash) {
+      _ = _lodash.default;
+    }, function (_showdownMinJs) {
+      showdown = _showdownMinJs.default;
+    }, function (_query_builder) {
+      queryBuilder = _query_builder;
+    }],
+    execute: function () {
+      _createClass = function () {
+        function defineProperties(target, props) {
+          for (var i = 0; i < props.length; i++) {
+            var descriptor = props[i];
+            descriptor.enumerable = descriptor.enumerable || false;
+            descriptor.configurable = true;
+            if ("value" in descriptor) descriptor.writable = true;
+            Object.defineProperty(target, descriptor.key, descriptor);
           }
+        }
 
-          return {
-            annotation: options.annotation,
-            time: event.date_happened * 1000,
-            title: eventStream.title,
-            text: renderedText,
-            tags: eventStream.tags
-          };
-        });
-      });
+        return function (Constructor, protoProps, staticProps) {
+          if (protoProps) defineProperties(Constructor.prototype, protoProps);
+          if (staticProps) defineProperties(Constructor, staticProps);
+          return Constructor;
+        };
+      }();
 
-      return _.flatten(eventAnnotations);
-    });
-  }
+      _export('DataDogDatasource', DataDogDatasource = function () {
+        function DataDogDatasource(instanceSettings, backendSrv, templateSrv) {
+          _classCallCheck(this, DataDogDatasource);
 
-  getHosts() {
-    return this.searchEntities('hosts');
-  }
+          this.type = instanceSettings.type;
+          this.url = instanceSettings.url;
+          this.name = instanceSettings.name;
+          this.api_key = instanceSettings.jsonData.api_key;
+          this.application_key = instanceSettings.jsonData.app_key;
+          this.supportMetrics = true;
+          this.backendSrv = backendSrv;
+          this.templateSrv = templateSrv;
+          this._cached_metrics = false;
+        }
 
-  // entity should be 'hosts' or 'metrics'
-  // http://docs.datadoghq.com/api/?lang=console#search
-  searchEntities(entity) {
-    let params = {q: ''};
-    if (entity) {
-      params.q = `${entity}:`;
+        // Function to check Datasource health
+
+
+        _createClass(DataDogDatasource, [{
+          key: 'testDatasource',
+          value: function testDatasource() {
+            return this.invokeDataDogApiRequest('/downtime').then(function () {
+              return {
+                status: "success",
+                title: "Success",
+                message: "Data source is working"
+              };
+            }).catch(function (error) {
+              var message = "Connection error";
+              if (error && error.message) {
+                message = error.message;
+              }
+
+              return {
+                status: "error",
+                title: "Error",
+                message: message
+              };
+            });
+          }
+        }, {
+          key: 'tagFindQuery',
+          value: function tagFindQuery() {
+            return this.getTagsFromCache().then(function (tags) {
+              return _.map(tags, function (hosts, tag) {
+                return {
+                  text: tag,
+                  value: tag
+                };
+              });
+            });
+          }
+        }, {
+          key: 'metricFindQuery',
+          value: function metricFindQuery(query) {
+            var _this = this;
+
+            if (query === 'tag') {
+              return this.tagFindQuery();
+            }
+
+            if (this._cached_metrics) {
+              return Promise.resolve(this._cached_metrics);
+            }
+
+            if (this.fetching) {
+              return this.fetching;
+            }
+
+            var d = new Date();
+            d.setDate(d.getDate() - 1);
+            var from = Math.floor(d.getTime() / 1000);
+
+            this.fetching = this.getMetrics(from).then(function (metrics) {
+              _this._cached_metrics = _.map(metrics, function (metric) {
+                return {
+                  text: metric,
+                  value: metric
+                };
+              });
+
+              return _this._cached_metrics;
+            });
+
+            return this.fetching;
+          }
+        }, {
+          key: 'getTagKeys',
+          value: function getTagKeys() {
+            return this.getTagsFromCache().then(function (tagsHosts) {
+              var tags = Object.keys(tagsHosts);
+              var kv = mapTagsToKVPairs(tags);
+              var grafanaTags = Object.keys(kv);
+
+              return grafanaTags.map(function (tag) {
+                return {
+                  text: tag,
+                  value: tag
+                };
+              });
+            });
+          }
+        }, {
+          key: 'getTagValues',
+          value: function getTagValues(options) {
+            return this.getTagsFromCache().then(function (tagsHosts) {
+              var tags = Object.keys(tagsHosts);
+              var kv = mapTagsToKVPairs(tags);
+              var grafanaValues = kv[options.key];
+              return grafanaValues.map(function (val) {
+                return {
+                  text: val,
+                  value: val
+                };
+              });
+            });
+          }
+        }, {
+          key: 'query',
+          value: function query(options) {
+            var from = Math.floor(options.range.from.valueOf() / 1000);
+            var to = Math.floor(options.range.to.valueOf() / 1000);
+
+            var targets = options.targets.filter(function (t) {
+              return !t.hide;
+            });
+
+            if (targets.length <= 0) {
+              return Promise.resolve({ data: [] });
+            }
+
+            // add global adhoc filters
+            var adhocFilters = this.templateSrv.getAdhocFilters(this.name);
+
+            var queries = _.map(targets, function (target) {
+              var query = void 0;
+              if (target.rawQuery) {
+                query = target.query;
+              } else {
+                query = queryBuilder.buildQuery(target, adhocFilters);
+              }
+              return query;
+            });
+
+            var queryString = queries.join(',');
+            queryString = this.templateSrv.replace(queryString, options.scopedVars, dataDogTagFormat);
+
+            var params = {
+              from: from,
+              to: to,
+              query: queryString
+            };
+
+            return this.invokeDataDogApiRequest('/query', params).then(function (result) {
+              var dataResponse = _.map(result.series, function (series, i) {
+                var target = targets[i];
+                return {
+                  'target': series.expression,
+                  'datapoints': _.map(series.pointlist, function (point) {
+                    return [point[1], point[0]];
+                  })
+                };
+              });
+
+              return { data: dataResponse };
+            });
+          }
+        }, {
+          key: 'annotationQuery',
+          value: function annotationQuery(options) {
+            var timeFrom = Math.floor(options.range.from.valueOf() / 1000);
+            var timeTo = Math.floor(options.range.to.valueOf() / 1000);
+            var _options$annotation = options.annotation,
+                priority = _options$annotation.priority,
+                sources = _options$annotation.sources,
+                tags = _options$annotation.tags;
+
+
+            return this.getEventStream(timeFrom, timeTo, priority, sources, tags).then(function (eventStreams) {
+              var eventAnnotations = eventStreams.map(function (eventStream) {
+                var allEvents = eventStream.children;
+                var filteredEvents = _.filter(allEvents, function (event) {
+                  return event.alert_type !== 'success';
+                });
+
+                return _.map(filteredEvents, function (event) {
+                  var renderedText = eventStream.text;
+                  if (isDataDogMarkdown(eventStream.text)) {
+                    renderedText = convertDataDogMdToHtml(eventStream.text);
+                  }
+
+                  return {
+                    annotation: options.annotation,
+                    time: event.date_happened * 1000,
+                    title: eventStream.title,
+                    text: renderedText,
+                    tags: eventStream.tags
+                  };
+                });
+              });
+
+              return _.flatten(eventAnnotations);
+            });
+          }
+        }, {
+          key: 'getHosts',
+          value: function getHosts() {
+            return this.searchEntities('hosts');
+          }
+        }, {
+          key: 'searchEntities',
+          value: function searchEntities(entity) {
+            var params = { q: '' };
+            if (entity) {
+              params.q = entity + ':';
+            }
+
+            return this.invokeDataDogApiRequest('/search', params).then(function (result) {
+              if (result && result.results) {
+                return result.results[entity];
+              }
+            });
+          }
+        }, {
+          key: 'getMetrics',
+          value: function getMetrics(timeFrom) {
+            var params = {};
+
+            if (timeFrom) {
+              params.from = timeFrom;
+            }
+
+            return this.invokeDataDogApiRequest('/metrics', params).then(function (result) {
+              if (result.metrics) {
+                return result.metrics;
+              } else {
+                return [];
+              }
+            });
+          }
+        }, {
+          key: 'getTagsHosts',
+          value: function getTagsHosts() {
+            return this.invokeDataDogApiRequest('/tags/hosts').then(function (result) {
+              if (result && result.tags) {
+                return result.tags;
+              }
+            });
+          }
+        }, {
+          key: 'getTagsFromCache',
+          value: function getTagsFromCache() {
+            var _this2 = this;
+
+            var getTags = void 0;
+            if (this._cached_tags && this._cached_tags.length) {
+              getTags = Promise.resolve(this._cached_tags);
+            } else {
+              getTags = this.getTagsHosts().then(function (tags) {
+                _this2._cached_tags = tags;
+                return tags;
+              });
+            }
+
+            return getTags;
+          }
+        }, {
+          key: 'getEventStream',
+          value: function getEventStream(timeFrom, timeTo, priority, sources, tags) {
+            var params = {
+              start: timeFrom,
+              end: timeTo
+            };
+            if (priority) {
+              params.priority = priority;
+            }
+            if (sources) {
+              params.sources = sources;
+            }
+            if (tags) {
+              params.tags = tags;
+            }
+
+            return this.invokeDataDogApiRequest('/events', params).then(function (result) {
+              if (result.events) {
+                return result.events;
+              } else {
+                return [];
+              }
+            });
+          }
+        }, {
+          key: 'invokeDataDogApiRequest',
+          value: function invokeDataDogApiRequest(url) {
+            var params = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+
+            // Set auth params
+            params.api_key = this.api_key;
+            params.application_key = this.application_key;
+
+            return this.backendSrv.datasourceRequest({
+              method: 'GET',
+              url: this.url + url,
+              params: params
+            }).then(function (response) {
+              if (response.data) {
+                return response.data;
+              } else {
+                throw { message: 'DataDog API request error' };
+              }
+            }).catch(function (error) {
+              var message = 'DataDog API request error';
+              if (error.statusText) {
+                message = error.status + ' ' + error.statusText;
+                throw { message: message };
+              } else if (error.err.statusText) {
+                throw { message: error.err.statusText };
+              } else {
+                throw { message: message };
+              }
+            });
+          }
+        }]);
+
+        return DataDogDatasource;
+      }());
+
+      _export('DataDogDatasource', DataDogDatasource);
     }
-
-    return this.invokeDataDogApiRequest('/search', params)
-    .then(result => {
-      if (result && result.results) {
-        return result.results[entity];
-      }
-    });
-  }
-
-  getMetrics(timeFrom) {
-    let params = {};
-
-    if (timeFrom) {
-      params.from = timeFrom;
-    }
-
-    return this.invokeDataDogApiRequest('/metrics', params)
-    .then(result => {
-      if (result.metrics) {
-        return result.metrics;
-      } else {
-        return [];
-      }
-    });
-  }
-
-  getTagsHosts() {
-    return this.invokeDataDogApiRequest('/tags/hosts')
-    .then(result => {
-      if (result && result.tags) {
-        return result.tags;
-      }
-    });
-  }
-
-  getTagsFromCache() {
-    let getTags;
-    if (this._cached_tags && this._cached_tags.length) {
-      getTags = Promise.resolve(this._cached_tags);
-    } else {
-      getTags = this.getTagsHosts().then(tags => {
-        this._cached_tags = tags;
-        return tags;
-      });
-    }
-
-    return getTags;
-  }
-
-  getEventStream(timeFrom, timeTo, priority, sources, tags) {
-    let params = {
-      start: timeFrom,
-      end: timeTo
-    };
-    if (priority) {
-      params.priority = priority;
-    }
-    if (sources) {
-      params.sources = sources;
-    }
-    if (tags) {
-      params.tags = tags;
-    }
-
-    return this.invokeDataDogApiRequest('/events', params)
-    .then(result => {
-      if (result.events) {
-        return result.events;
-      } else {
-        return [];
-      }
-    });
-  }
-
-  invokeDataDogApiRequest(url, params = {}) {
-    // Set auth params
-    params.api_key = this.api_key;
-    params.application_key = this.application_key;
-
-    return this.backendSrv.datasourceRequest({
-      method: 'GET',
-      url: this.url + url,
-      params: params
-    })
-    .then(response => {
-      if (response.data) {
-        return response.data;
-      } else {
-        throw {message: 'DataDog API request error'};
-      }
-    })
-    .catch(error => {
-      var message = 'DataDog API request error';
-      if (error.statusText) {
-        message = error.status + ' ' + error.statusText;
-        throw {message: message};
-      } else if (error.err.statusText) {
-        throw {message: error.err.statusText};
-      } else {
-        throw {message: message};
-      }
-    });
-  }
-}
-
-/*
- * Convert tags to key-value pairs
- * [region:east, region:nw] => {region: [east, nw]}
- */
-function mapTagsToKVPairs(tags) {
-  let kv_tags = _.filter(tags, tag => {
-    return (tag.indexOf(':') !== -1);
-  });
-
-  let kv_pairs = kv_tags.map(tag => {
-    return tag.split(':', 2); // Limit to 2
-  });
-
-  let kv_object = {};
-  kv_pairs.forEach(pair => {
-    let key = pair[0];
-    let val = pair[1];
-
-    if (kv_object[key]) {
-      kv_object[key].push(val);
-    } else {
-      kv_object[key] = [val];
-    }
-  });
-
-  return kv_object;
-}
-
-/*
- * Convert DataDog event text from markdown to pure HTML
- * http://docs.datadoghq.com/guides/markdown/
- */
-function convertDataDogMdToHtml(str) {
-  const MD_START = '%%%\n';
-  const MD_END = '\n%%%';
-
-  let md_start_index = str.indexOf(MD_START) + MD_START.length;
-  let md_end_index = str.indexOf(MD_END);
-  let md = str.substring(md_start_index, md_end_index);
-  md = removeImagesFromDataDogMarkdown(md);
-
-  let converter = new showdown.Converter();
-  return converter.makeHtml(md);
-}
-
-function isDataDogMarkdown(str) {
-  const MD_START = '%%%\n';
-  return str.indexOf(MD_START) >= 0;
-}
-
-function removeImagesFromDataDogMarkdown(str) {
-  let dataDogImagePattern = /\[{0,1}\!\[.*\]\(https{0,1}\:\/\/p\.datadoghq\.com\/snapshot.+\)/g;
-  return str.replace(dataDogImagePattern, '');
-}
-
-function dataDogTagFormat(value) {
-  if (_.isArray(value)) {
-    return value.join(',');
-  }
-  return value;
-}
+  };
+});
+//# sourceMappingURL=datasource.js.map

--- a/src/partials/query.editor.html
+++ b/src/partials/query.editor.html
@@ -1,7 +1,7 @@
 <query-editor-row query-ctrl="ctrl" has-text-edit-mode="true" can-collapse="true">
 
   <div class="gf-form" ng-if="ctrl.target.rawQuery">
-    <input type="text" class="gf-form-input" ng-model="ctrl.target.query" spellcheck="false" ng-blur="ctrl.refresh()"></input>
+    <input type="text" class="gf-form-input" ng-model="ctrl.target.query" spellcheck="false" ng-blur="ctrl.checkQuery()"></input>
   </div>
 
   <div ng-if="!ctrl.target.rawQuery">
@@ -21,7 +21,7 @@
       </div>
 
       <div class="gf-form gf-form--grow">
-        <div class="gf-form-label gf-form-label--grow"></div>
+        <div class="gf-form-label gf-form-label--grow"></div> 
       </div>
     </div>
 
@@ -54,6 +54,17 @@
         <div class="gf-form-label gf-form-label--grow"></div>
       </div>
 
+    </div>
+
+    <div class="gf-form-inline">
+      <div class="gf-form max-width-30">
+        <label class="gf-form-label query-keyword width-7">GROUP BY</label>
+        <input type="text" class="gf-form-input" ng-model="ctrl.target.groups" spellcheck='false' placeholder="Tags (separate by comma)" ng-blur="ctrl.refresh()">
+      </div>
+
+      <div class="gf-form gf-form--grow">
+        <div class="gf-form-label gf-form-label--grow"></div>
+      </div>
     </div>
 
     <div class="gf-form-inline">

--- a/src/query_builder.js
+++ b/src/query_builder.js
@@ -1,65 +1,97 @@
-import _ from 'lodash';
-import dfunc from './dfunc';
+'use strict';
 
-export function buildQuery(target, adhocFilters) {
-  let {aggregation, metric, tags, functions} = target;
-  let query = `${aggregation}:${metric}`;
+System.register(['lodash', './dfunc'], function (_export, _context) {
+  "use strict";
 
-  let functionInstances  = getFunctionInstances(functions);
+  var _, dfunc;
 
-  if ((tags && tags.length) || (adhocFilters && adhocFilters.length)) {
-    query += '{';
+  function buildQuery(target, adhocFilters) {
+    var aggregation = target.aggregation,
+        metric = target.metric,
+        tags = target.tags,
+        functions = target.functions;
 
-    if (tags && tags.length) {
-      query += tags.join(',');
-    }
+    var query = aggregation + ':' + metric;
 
-    if (adhocFilters && adhocFilters.length) {
-      let adhocTags = buildAdHocFilterString(adhocFilters);
+    var functionInstances = getFunctionInstances(functions);
+
+    if (tags && tags.length || adhocFilters && adhocFilters.length) {
+      query += '{';
+
       if (tags && tags.length) {
-        query += ',';
+        query += tags.join(',');
       }
-      query += adhocTags;
-    }
 
-    query += '}';
-  } else {
-    query += '{*}';
-  }
+      if (adhocFilters && adhocFilters.length) {
+        var adhocTags = buildAdHocFilterString(adhocFilters);
+        if (tags && tags.length) {
+          query += ',';
+        }
+        query += adhocTags;
+      }
 
-  if (target.as) {
-    query += '.' + target.as + '()';
-  }
-
-  var groupedFuncs = _.groupBy(functionInstances, func => {
-    if (func.def.append) {
-      return 'appends';
+      query += '}';
     } else {
-      return 'wraps';
+      query += '{*}';
     }
-  });
 
-  _.each(groupedFuncs.appends, func => {
-    query += '.' + func.render();
-  });
+    if (target.groups) {
+      var groups = target.groups.split(",");
+      query += ' by {';
+      for (var i = 0; i < groups.length; ++i) {
+        query += groups[i];
+        if (i !== groups.length - 1) {
+          query += ',';
+        }
+      }
+      query += '}';
+    }
 
-  _.each(groupedFuncs.wraps, func => {
-    query = func.render(query);
-  });
+    if (target.as) {
+      query += '.' + target.as + '()';
+    }
 
-  return query;
-}
+    var groupedFuncs = _.groupBy(functionInstances, function (func) {
+      if (func.def.append) {
+        return 'appends';
+      } else {
+        return 'wraps';
+      }
+    });
 
-function getFunctionInstances(functions) {
-  return _.map(functions, func => {
-    var f = dfunc.createFuncInstance(func.funcDef, {withDefaultParams: false});
-    f.params = func.params.slice();
-    return f;
-  });
-}
+    _.each(groupedFuncs.appends, function (func) {
+      query += '.' + func.render();
+    });
 
-function buildAdHocFilterString(adhocFilters) {
-  return adhocFilters.map(filter => {
-    return filter.key + ':' + filter.value;
-  }).join(',');
-}
+    _.each(groupedFuncs.wraps, function (func) {
+      query = func.render(query);
+    });
+  
+    return query;
+  }
+
+  _export('buildQuery', buildQuery);
+
+  function getFunctionInstances(functions) {
+    return _.map(functions, function (func) {
+      var f = dfunc.createFuncInstance(func.funcDef, { withDefaultParams: false });
+      f.params = func.params.slice();
+      return f;
+    });
+  }
+
+  function buildAdHocFilterString(adhocFilters) {
+    return adhocFilters.map(function (filter) {
+      return filter.key + ':' + filter.value;
+    }).join(',');
+  }
+  return {
+    setters: [function (_lodash) {
+      _ = _lodash.default;
+    }, function (_dfunc) {
+      dfunc = _dfunc.default;
+    }],
+    execute: function () {}
+  };
+});
+//# sourceMappingURL=query_builder.js.map

--- a/src/query_ctrl.js
+++ b/src/query_ctrl.js
@@ -1,185 +1,270 @@
-import _ from 'lodash';
-import dfunc from './dfunc';
-import {QueryCtrl} from 'app/plugins/sdk';
-import './func_editor';
-import './add_datadog_func';
-import * as queryBuilder from './query_builder';
+'use strict';
 
-export class DataDogQueryCtrl extends QueryCtrl {
+System.register(['lodash', './dfunc', 'app/plugins/sdk', './func_editor', './add_datadog_func', './query_builder'], function (_export, _context) {
+  "use strict";
 
-  constructor($scope, $injector, uiSegmentSrv, templateSrv)  {
-    super($scope, $injector);
-    this.removeText = '-- remove tag --';
-    this.uiSegmentSrv = uiSegmentSrv;
-    this.templateSrv = templateSrv;
+  var _, dfunc, QueryCtrl, queryBuilder, _createClass, DataDogQueryCtrl;
 
-    if (this.target.aggregation) {
-      this.aggregationSegment = new uiSegmentSrv.newSegment(
-        this.target.aggregation
-      );
-    } else {
-      this.aggregationSegment = new uiSegmentSrv.newSegment({
-        value: 'Select Aggregation',
-        fake: true,
-        custom: false,
-      });
+  function _classCallCheck(instance, Constructor) {
+    if (!(instance instanceof Constructor)) {
+      throw new TypeError("Cannot call a class as a function");
+    }
+  }
+
+  function _possibleConstructorReturn(self, call) {
+    if (!self) {
+      throw new ReferenceError("this hasn't been initialised - super() hasn't been called");
     }
 
-    if (this.target.metric) {
-      this.metricSegment = new uiSegmentSrv.newSegment(
-        this.target.metric
-      );
-    } else {
-      this.metricSegment = new uiSegmentSrv.newSegment({
-        value: 'Select Metric',
-        fake: true,
-        custom: false,
-      });
+    return call && (typeof call === "object" || typeof call === "function") ? call : self;
+  }
+
+  function _inherits(subClass, superClass) {
+    if (typeof superClass !== "function" && superClass !== null) {
+      throw new TypeError("Super expression must either be null or a function, not " + typeof superClass);
     }
 
-    this.target.tags = this.target.tags || [];
-    this.tagSegments = this.target.tags.map(uiSegmentSrv.newSegment);
-    this.fixTagSegments();
-
-    this.functions = [];
-    this.target.functions = this.target.functions || [];
-    this.functions = _.map(this.target.functions, func => {
-      var f = dfunc.createFuncInstance(func.funcDef, {withDefaultParams: false});
-      f.params = func.params.slice();
-      return f;
-    });
-
-    if (this.target.as) {
-      this.asSegment = uiSegmentSrv.newSegment(this.target.as);
-    } else {
-      this.asSegment = uiSegmentSrv.newSegment({
-        value: 'Select As',
-        fake: true,
-        custom: false,
-      });
-    }
-
-  }
-
-  toggleEditorMode() {
-    this.target.rawQuery = !this.target.rawQuery;
-  }
-
-  getMetrics() {
-    return this.datasource.metricFindQuery()
-    .then(this.uiSegmentSrv.transformToSegments(true));
-  }
-
-  getAggregations() {
-    return Promise.resolve([
-      {text: 'avg by', value: 'avg'},
-      {text: 'max by', value: 'max'},
-      {text: 'min by', value: 'min'},
-      {text: 'sub by', value: 'sum'},
-    ]);
-  }
-
-  getAs() {
-    return Promise.resolve([
-      {text: 'None', value: 'None'},
-      {text: 'as_count', value: 'as_count'},
-      {text: 'as_rate', value: 'as_rate'},
-    ]);
-  }
-
-  getTags(segment) {
-    return this.datasource.tagFindQuery()
-    .then(this.uiSegmentSrv.transformToSegments(true))
-    .then(results => {
-      if (segment.type !== 'plus-button') {
-        let removeSegment = this.uiSegmentSrv.newFake(this.removeText);
-        results.unshift(removeSegment);
+    subClass.prototype = Object.create(superClass && superClass.prototype, {
+      constructor: {
+        value: subClass,
+        enumerable: false,
+        writable: true,
+        configurable: true
       }
-
-      return results;
     });
+    if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass;
   }
 
-  aggregationChanged() {
-    this.target.aggregation = this.aggregationSegment.value;
-    this.panelCtrl.refresh();
-  }
+  return {
+    setters: [function (_lodash) {
+      _ = _lodash.default;
+    }, function (_dfunc) {
+      dfunc = _dfunc.default;
+    }, function (_appPluginsSdk) {
+      QueryCtrl = _appPluginsSdk.QueryCtrl;
+    }, function (_func_editor) {}, function (_add_datadog_func) {}, function (_query_builder) {
+      queryBuilder = _query_builder;
+    }],
+    execute: function () {
+      _createClass = function () {
+        function defineProperties(target, props) {
+          for (var i = 0; i < props.length; i++) {
+            var descriptor = props[i];
+            descriptor.enumerable = descriptor.enumerable || false;
+            descriptor.configurable = true;
+            if ("value" in descriptor) descriptor.writable = true;
+            Object.defineProperty(target, descriptor.key, descriptor);
+          }
+        }
 
-  metricChanged() {
-    this.target.metric = this.metricSegment.value;
-    this.panelCtrl.refresh();
-  }
+        return function (Constructor, protoProps, staticProps) {
+          if (protoProps) defineProperties(Constructor.prototype, protoProps);
+          if (staticProps) defineProperties(Constructor, staticProps);
+          return Constructor;
+        };
+      }();
 
-  asChanged() {
-    if (this.asSegment.value === 'None') {
-      this.target.as = null;
-    } else {
-      this.target.as = this.asSegment.value;
+      _export('DataDogQueryCtrl', DataDogQueryCtrl = function (_QueryCtrl) {
+        _inherits(DataDogQueryCtrl, _QueryCtrl);
+
+        function DataDogQueryCtrl($scope, $injector, uiSegmentSrv, templateSrv) {
+          _classCallCheck(this, DataDogQueryCtrl);
+
+          var _this = _possibleConstructorReturn(this, (DataDogQueryCtrl.__proto__ || Object.getPrototypeOf(DataDogQueryCtrl)).call(this, $scope, $injector));
+
+          _this.removeText = '-- remove tag --';
+          _this.uiSegmentSrv = uiSegmentSrv;
+          _this.templateSrv = templateSrv;
+
+          if (_this.target.aggregation) {
+            _this.aggregationSegment = new uiSegmentSrv.newSegment(_this.target.aggregation);
+          } else {
+            _this.aggregationSegment = new uiSegmentSrv.newSegment({
+              value: 'Select Aggregation',
+              fake: true,
+              custom: false
+            });
+          }
+
+          if (_this.target.metric) {
+            _this.metricSegment = new uiSegmentSrv.newSegment(_this.target.metric);
+          } else {
+            _this.metricSegment = new uiSegmentSrv.newSegment({
+              value: 'Select Metric',
+              fake: true,
+              custom: false
+            });
+          }
+
+          _this.target.tags = _this.target.tags || [];
+          _this.tagSegments = _this.target.tags.map(uiSegmentSrv.newSegment);
+          _this.fixTagSegments();
+
+          _this.functions = [];
+          _this.target.functions = _this.target.functions || [];
+          _this.functions = _.map(_this.target.functions, function (func) {
+            var f = dfunc.createFuncInstance(func.funcDef, { withDefaultParams: false });
+            f.params = func.params.slice();
+            return f;
+          });
+
+          if (_this.target.as) {
+            _this.asSegment = uiSegmentSrv.newSegment(_this.target.as);
+          } else {
+            _this.asSegment = uiSegmentSrv.newSegment({
+              value: 'Select As',
+              fake: true,
+              custom: false
+            });
+          }
+
+          return _this;
+        }
+
+        _createClass(DataDogQueryCtrl, [{
+          key: 'toggleEditorMode',
+          value: function toggleEditorMode() {
+            this.target.rawQuery = !this.target.rawQuery;
+            if (this.target.rawQuery)
+              this.target.query = queryBuilder.buildQuery(this.target);
+          }
+        }, {
+          key: 'getCollapsedText',
+          value: function getCollapsedText() {
+            if (this.target.rawQuery) {
+              return this.target.query;
+            } else {
+              return queryBuilder.buildQuery(this.target);
+            }
+          }
+        }, {
+          key: 'checkQuery',
+          value: function checkQuery() {
+            if (!(this.target.query || this.target.query.length != 0)) 
+            // to avoid 400 Bad Request, this is the default query
+              this.target.query = 'undefined:undefined{*}';
+            this.panelCtrl.refresh();
+          }
+        }, {
+          key: 'getMetrics',
+          value: function getMetrics() {
+            return this.datasource.metricFindQuery().then(this.uiSegmentSrv.transformToSegments(true));
+          }
+        }, {
+          key: 'getAggregations',
+          value: function getAggregations() {
+            return Promise.resolve([{ text: 'avg by', value: 'avg' }, { text: 'max by', value: 'max' }, { text: 'min by', value: 'min' }, { text: 'sub by', value: 'sum' }]);
+          }
+        }, {
+          key: 'getAs',
+          value: function getAs() {
+            return Promise.resolve([{ text: 'None', value: 'None' }, { text: 'as_count', value: 'as_count' }, { text: 'as_rate', value: 'as_rate' }]);
+          }
+        }, {
+          key: 'getTags',
+          value: function getTags(segment) {
+            var _this2 = this;
+
+            return this.datasource.tagFindQuery().then(this.uiSegmentSrv.transformToSegments(true)).then(function (results) {
+              if (segment.type !== 'plus-button') {
+                var removeSegment = _this2.uiSegmentSrv.newFake(_this2.removeText);
+                results.unshift(removeSegment);
+              }
+
+              return results;
+            });
+          }
+        }, {
+          key: 'aggregationChanged',
+          value: function aggregationChanged() {
+            this.target.aggregation = this.aggregationSegment.value;
+            this.panelCtrl.refresh();
+          }
+        }, {
+          key: 'metricChanged',
+          value: function metricChanged() {
+            this.target.metric = this.metricSegment.value;
+            this.panelCtrl.refresh();
+          }
+        }, {
+          key: 'asChanged',
+          value: function asChanged() {
+            this.target.as = this.asSegment.value;
+            this.panelCtrl.refresh();
+          }
+        }, {
+          key: 'fixTagSegments',
+          value: function fixTagSegments() {
+            var count = this.tagSegments.length;
+            var lastSegment = this.tagSegments[Math.max(count - 1, 0)];
+
+            if (!lastSegment || lastSegment.type !== 'plus-button') {
+              this.tagSegments.push(this.uiSegmentSrv.newPlusButton());
+            }
+          }
+        }, {
+          key: 'targetChanged',
+          value: function targetChanged() {
+            if (this.error) {
+              return;
+            }
+
+            this.panelCtrl.refresh();
+          }
+        }, {
+          key: 'persistFunctions',
+          value: function persistFunctions() {
+            this.target.functions = _.map(this.functions, function (func) {
+              return {
+                funcDef: func.def.name,
+                params: func.params.slice()
+              };
+            });
+          }
+        }, {
+          key: 'removeFunction',
+          value: function removeFunction(func) {
+            this.functions = _.without(this.functions, func);
+            this.persistFunctions();
+            this.targetChanged();
+          }
+        }, {
+          key: 'addFunction',
+          value: function addFunction(funcDef) {
+            var func = dfunc.createFuncInstance(funcDef, { withDefaultParams: true });
+            func.added = true;
+            this.functions.push(func);
+            this.persistFunctions();
+            this.targetChanged();
+          }
+        }, {
+          key: 'tagSegmentUpdated',
+          value: function tagSegmentUpdated(segment, index) {
+            if (segment.value === this.removeText) {
+              this.tagSegments.splice(index, 1);
+            }
+
+            var realSegments = _.filter(this.tagSegments, function (segment) {
+              return segment.value;
+            });
+            this.target.tags = realSegments.map(function (segment) {
+              return segment.value;
+            });
+
+            this.tagSegments = _.map(this.target.tags, this.uiSegmentSrv.newSegment);
+            this.fixTagSegments();
+
+            this.panelCtrl.refresh();
+          }
+        }]);
+
+        return DataDogQueryCtrl;
+      }(QueryCtrl));
+
+      _export('DataDogQueryCtrl', DataDogQueryCtrl);
+
+      DataDogQueryCtrl.templateUrl = 'partials/query.editor.html';
     }
-    this.panelCtrl.refresh();
-  }
-
-  fixTagSegments() {
-    var count = this.tagSegments.length;
-    var lastSegment = this.tagSegments[Math.max(count-1, 0)];
-
-    if (!lastSegment || lastSegment.type !== 'plus-button') {
-      this.tagSegments.push(this.uiSegmentSrv.newPlusButton());
-    }
-  }
-
-  targetChanged() {
-    if (this.error) {
-      return;
-    }
-
-    this.panelCtrl.refresh();
-  }
-
-  persistFunctions () {
-    this.target.functions = _.map(this.functions, func => {
-      return {
-        funcDef: func.def.name,
-        params: func.params.slice(),
-      };
-    });
-  }
-
-  removeFunction(func) {
-    this.functions = _.without(this.functions, func);
-    this.persistFunctions();
-    this.targetChanged();
-  }
-
-  addFunction(funcDef) {
-    var func = dfunc.createFuncInstance(funcDef, {withDefaultParams: true});
-    func.added = true;
-    this.functions.push(func);
-    this.persistFunctions();
-    this.targetChanged();
-  }
-
-  tagSegmentUpdated(segment, index) {
-    if (segment.value === this.removeText) {
-      this.tagSegments.splice(index, 1);
-    }
-
-    let realSegments = _.filter(this.tagSegments, segment => segment.value);
-    this.target.tags = realSegments.map(segment => segment.value);
-
-    this.tagSegments = _.map(this.target.tags, this.uiSegmentSrv.newSegment);
-    this.fixTagSegments();
-
-    this.panelCtrl.refresh();
-  }
-
-  getCollapsedText() {
-    if (this.target.rawQuery) {
-      return this.target.query;
-    } else {
-      return queryBuilder.buildQuery(this.target);
-    }
-  }
-}
-
-DataDogQueryCtrl.templateUrl = 'partials/query.editor.html';
+  };
+});
+//# sourceMappingURL=query_ctrl.js.map


### PR DESCRIPTION
**Changes**
I have to revert all the package versions back to the old versions. While the plugin works locally, after re-building the `dist` folder with all the new packages, the plugin couldn't be loaded locally anymore. 

**Attempts**
1. Updated to Babel 7 but `es2015` is not compatible with it
2. Updated `es2015` to `@babel/preset-env` but encountered `export` issue
3. Tried to stay with `es2015` but `grunt` requires `babel@7.0.0` or higher which broke everything else again

**Note**
Please use `node@6.9.1` when `npm install`

I will manually edit `dist` for now so that it would work. I will further investigate it.